### PR TITLE
Set DevelopmentDependency to true

### DIFF
--- a/src/UnoptimizedAssemblyDetector/UnoptimizedAssemblyDetector.csproj
+++ b/src/UnoptimizedAssemblyDetector/UnoptimizedAssemblyDetector.csproj
@@ -18,6 +18,7 @@
     <DebugType>embedded</DebugType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>unoptimized.png</PackageIcon>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CraftRelease)' != 'true'">


### PR DESCRIPTION
Setting the `DevelopmentDependency` to `true` will make NuGet client set the assets to private.

Currently NuGet shows the following:
![image](https://user-images.githubusercontent.com/534533/119531519-e9702500-bd7b-11eb-8cbd-b1923751f224.png)

NuGet shows the following on a package that has the flag set:
![image](https://user-images.githubusercontent.com/534533/119531799-30f6b100-bd7c-11eb-817b-4e1355ffc4bd.png)



